### PR TITLE
순위 검색(프로그래머스)

### DIFF
--- a/KangHayeonn/programmers/SearchRank.java
+++ b/KangHayeonn/programmers/SearchRank.java
@@ -1,0 +1,66 @@
+// 순위 검색 (프로그래머스 LEVEL2)
+import java.util.*;
+
+class Solution {
+    	static Map<String, ArrayList<Integer>> map = new HashMap<>();
+	static ArrayList<Integer> arr;
+    	public int[] solution(String[] info, String[] query) {
+		String[] strArr;
+		String str;
+		
+		for(int i=0; i<info.length; i++) {
+			strArr = info[i].split(" ");
+			combination("", 0, strArr);
+		}
+		
+		List<String> list = new ArrayList<>(map.keySet());
+		for(int i=0; i<list.size(); i++) {
+			arr = map.get(list.get(i));
+			Collections.sort(arr);
+		}
+		
+		int[] answer = new int[query.length];
+		for(int i=0; i<query.length; i++) {
+			str = query[i].replaceAll(" and ", "");
+			strArr = str.split(" ");
+			answer[i] = binarySearch(strArr[0], Integer.parseInt(strArr[1]));
+		}
+		
+		return answer;
+	}
+	// 조합
+	public static void combination(String str, int depth, String[] strArr) {
+		if(depth == 4) {
+			if(!map.containsKey(str)) {
+				arr = new ArrayList<Integer>();
+				arr.add(Integer.parseInt(strArr[4]));
+				map.put(str, arr);
+			} else {
+				map.get(str).add(Integer.parseInt(strArr[4]));
+			}
+			return;
+		}
+		
+		combination(str+strArr[depth], depth+1, strArr);
+		combination(str+"-", depth+1, strArr);
+	}
+	// 이분 탐색
+	public static int binarySearch(String str, int num) {
+		if(!map.containsKey(str)) return 0;
+		
+		arr = map.get(str);
+		int start = 0, end = arr.size()-1, mid = 0;
+
+		while(start <= end) {
+			mid = (start + end) / 2;
+			
+			if(arr.get(mid) < num) {
+				start = mid+1;
+			} else {
+				end = mid-1; 
+			}
+		}
+		
+		return arr.size() - start;
+	}
+}


### PR DESCRIPTION
## 문제 이름(번호/레벨) - 문제 사이트
- 순위 검색(LEVEL2) - 프로그래머스

## 알고리즘 로직
- 입력 데이터가 5만, 10만개로 완전 탐색으로 탐색할 경우 시간 초과가 나기 때문에 map과 이분 탐색을 이용한 탐색 방법을 선택한다.
- info 데이터를 점수를 제외한 나머지 문자열을 기준으로 나올 수 있는 모든 조합의 케이스를 map의 key값으로 저장한다.
- 이때, map의 value는 해당 key가 나올 때의 점수를 arraylist를 이용해 모두 저장해준다.
- 이후 각각의 arraylist 는 이분 탐색을 할 것이므로 map의 key별로 그 때의 value값인 arraylist를 정렬해준다.
- query에서 탐색할 string을 점수를 제외하고 묶어준다.
- 해당 string값이 map에 존재할 경우 그때의 value인 arraylist를 위에서 제외한 점수를 기준으로 이분 탐색해 해당 점수 이상의 개수를 answer 배열에 저장한다.

## 비고
- **알고리즘**
    - 이분탐색
    - 조합
    - 정렬
- **자료구조**
    - ArrayList
    - Map

## 작업일자
- 2022.08.17
